### PR TITLE
[native_pdf_renderer] FIXed backgroundColor fill for iOS

### DIFF
--- a/packages/native_pdf_renderer/ios/Classes/Hooks.swift
+++ b/packages/native_pdf_renderer/ios/Classes/Hooks.swift
@@ -18,15 +18,4 @@ extension UIColor {
         }
         self.init(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: CGFloat(a) / 255)
     }
-    
-    func toBytes() -> UInt8 {
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-        getRed(&r, green: &g, blue: &b, alpha: &a)
-        let rgb: Int = (Int)(a * 255)<<24 | (Int)(r * 255)<<16 | (Int)(g * 255)<<8 | (Int)(b * 255)<<0
-        let convertedRgb: Int8 = Int8(exactly: rgb) ?? 0
-        return UInt8(bitPattern: convertedRgb)
-    }
 }

--- a/packages/native_pdf_renderer/ios/Classes/document/Page.swift
+++ b/packages/native_pdf_renderer/ios/Classes/document/Page.swift
@@ -44,7 +44,7 @@ class Page {
     func render(width: Int, height: Int, compressFormat: CompressFormat, backgroundColor: UIColor) -> Page.DataResult? {
         let pdfBBox = renderer.getBoxRect(.mediaBox)
         let stride = width * 4
-        var tempData = Data(repeating: backgroundColor.toBytes(), count: stride * height)
+        var tempData = Data(repeating: 0, count: stride * height)
         var data: Data?
         var success = false
         let sx = CGFloat(width) / pdfBBox.width
@@ -54,6 +54,8 @@ class Page {
             let context = CGContext(data: ptr, width: width, height: height, bitsPerComponent: 8, bytesPerRow: stride, space: rgb, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
             if context != nil {
                 context!.scaleBy(x: sx, y: sy)
+                context!.setFillColor(backgroundColor.cgColor)
+                context!.fill(pdfBBox)
                 context!.drawPDFPage(renderer)
                 let image = UIImage(cgImage: context!.makeImage()!)
                 switch(compressFormat) {


### PR DESCRIPTION
For iOS the backgroundColor was not correctly used for filling the rendered image.

The pull request changes the logic of preparing de Data and fill the background of the image using the correct color passed in backgroundColor parameter.